### PR TITLE
Allow different QueueNameResolver for commands/events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "symfony/console": "~2.4",
-        "doctrine/dbal": "~2.4"
+        "doctrine/dbal": "~2.4",
+        "matthiasnoback/symfony-config-test": "~1.3"
     },
     "suggests": {
         "ext-mcrypt": "Allows encryption of messages.",

--- a/src/DependencyInjection/SimpleBusBernardBundleBridgeExtension.php
+++ b/src/DependencyInjection/SimpleBusBernardBundleBridgeExtension.php
@@ -92,6 +92,7 @@ class SimpleBusBernardBundleBridgeExtension extends ConfigurableExtension implem
                 $definition->replaceArgument(0, $config[$type]['queue_name']);
             } elseif ($queueNameResolver === 'mapped') {
                 $definition->replaceArgument(0, $config[$type]['queues_map']);
+                $definition->replaceArgument(1, $config[$type]['queue_name']);
             }
 
             $container->setDefinition(

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -37,6 +37,7 @@
 
         <service id="simple_bus.bernard_bundle_bridge.routing.mapped_queue_name_resolver" class="SimpleBus\BernardBundleBridge\Routing\MappedQueueNameResolver" public="false">
             <argument type="collection" />
+            <argument />
         </service>
 
         <!-- Listeners -->

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,14 +8,14 @@
         <service id="simple_bus.bernard_bundle_bridge.command_publisher" class="SimpleBus\BernardBundleBridge\BernardPublisher">
             <argument type="service" id="simple_bus.asynchronous.message_serializer" />
             <argument type="service" id="bernard.producer" />
-            <argument type="service" id="simple_bus.bernard_bundle_bridge.routing.queue_name_resolver" />
+            <argument type="service" id="simple_bus.bernard_bundle_bridge.routing.commands_queue_name_resolver" />
             <argument>command</argument>
         </service>
 
         <service id="simple_bus.bernard_bundle_bridge.event_publisher" class="SimpleBus\BernardBundleBridge\BernardPublisher">
             <argument type="service" id="simple_bus.asynchronous.message_serializer" />
             <argument type="service" id="bernard.producer" />
-            <argument type="service" id="simple_bus.bernard_bundle_bridge.routing.queue_name_resolver" />
+            <argument type="service" id="simple_bus.bernard_bundle_bridge.routing.events_queue_name_resolver" />
             <argument>event</argument>
         </service>
 
@@ -29,9 +29,13 @@
 
         <!-- Routing -->
 
-        <service id="simple_bus.bernard_bundle_bridge.routing.default_queue_name_resolver" class="SimpleBus\BernardBundleBridge\Routing\DefaultQueueNameResolver" />
+        <service id="simple_bus.bernard_bundle_bridge.routing.class_based_queue_name_resolver" class="SimpleBus\BernardBundleBridge\Routing\ClassBasedQueueNameResolver" public="false" />
 
-        <service id="simple_bus.bernard_bundle_bridge.routing.mapped_queue_name_resolver" class="SimpleBus\BernardBundleBridge\Routing\MappedQueueNameResolver">
+        <service id="simple_bus.bernard_bundle_bridge.routing.fixed_queue_name_resolver" class="SimpleBus\BernardBundleBridge\Routing\FixedQueueNameResolver" public="false">
+            <argument />
+        </service>
+
+        <service id="simple_bus.bernard_bundle_bridge.routing.mapped_queue_name_resolver" class="SimpleBus\BernardBundleBridge\Routing\MappedQueueNameResolver" public="false">
             <argument type="collection" />
         </service>
 

--- a/src/Routing/ClassBasedQueueNameResolver.php
+++ b/src/Routing/ClassBasedQueueNameResolver.php
@@ -4,7 +4,7 @@ namespace SimpleBus\BernardBundleBridge\Routing;
 
 use SimpleBus\Asynchronous\Routing\RoutingKeyResolver;
 
-class DefaultQueueNameResolver implements RoutingKeyResolver
+class ClassBasedQueueNameResolver implements RoutingKeyResolver
 {
     public function resolveRoutingKeyFor($message)
     {

--- a/src/Routing/FixedQueueNameResolver.php
+++ b/src/Routing/FixedQueueNameResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SimpleBus\BernardBundleBridge\Routing;
+
+use SimpleBus\Asynchronous\Routing\RoutingKeyResolver;
+
+class FixedQueueNameResolver implements RoutingKeyResolver
+{
+    /**
+     * @var string
+     */
+    private $queue;
+
+    /**
+     * @param string $queue
+     */
+    public function __construct($queue)
+    {
+        $this->queue = $queue;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolveRoutingKeyFor($message)
+    {
+        return $this->queue;
+    }
+}

--- a/src/Routing/MappedQueueNameResolver.php
+++ b/src/Routing/MappedQueueNameResolver.php
@@ -6,19 +6,35 @@ use SimpleBus\Asynchronous\Routing\RoutingKeyResolver;
 
 class MappedQueueNameResolver implements RoutingKeyResolver
 {
+    /**
+     * @var array
+     */
     private $map;
 
-    public function __construct(array $map)
+    /**
+     * @var string
+     */
+    private $default;
+
+    /**
+     * @param array  $map
+     * @param string $default
+     */
+    public function __construct(array $map, $default)
     {
         $this->map = $map;
+        $this->default = $default;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function resolveRoutingKeyFor($message)
     {
         $class = get_class($message);
 
         if (!isset($this->map[$class])) {
-            throw new \RuntimeException(sprintf('Unable to detect queue for message of type %s.', $class));
+            return $this->default;
         }
 
         return $this->map[$class];

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SimpleBus\BernardBundleBridge\Tests\DependencyInjection;
+
+use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
+use SimpleBus\BernardBundleBridge\DependencyInjection\Configuration;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    use ConfigurationTestCaseTrait;
+
+    protected function getConfiguration()
+    {
+        return new Configuration('simple_bus_bernard_bundle_bridge');
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_work_with_an_empty_configuration()
+    {
+        $this->assertProcessedConfigurationEquals(array(), array(
+            'commands' => array(
+                'queue_name_resolver' => 'fixed',
+                'queue_name' => 'asynchronous_commands',
+                'queues_map' => array(),
+            ),
+            'events' => array(
+                'queue_name_resolver' => 'fixed',
+                'queue_name' => 'asynchronous_events',
+                'queues_map' => array(),
+            ),
+            'encryption' => array(
+                'enabled' => false,
+                'encrypter' => 'nelmio',
+                'algorithm' => 'rijndael-128',
+                'secret' => '%kernel.secret%',
+            ),
+        ));
+    }
+
+    /**
+     * @test
+     * @dataProvider commandsAndEventsProvider
+     */
+    public function it_should_normalize_commands_and_events_to_fixed_queue_name($type)
+    {
+        $this->assertProcessedConfigurationEquals(array(
+            array($type => 'my-queue-name')
+        ), array(
+            $type => array(
+                'queue_name_resolver' => 'fixed',
+                'queue_name' => 'my-queue-name',
+                'queues_map' => array(),
+            )
+        ), $type);
+    }
+
+    /**
+     * @test
+     * @dataProvider commandsAndEventsProvider
+     */
+    public function it_should_be_possible_to_set_a_queue_name_map($type)
+    {
+        $this->assertProcessedConfigurationEquals(array(
+            array($type => array(
+                'queue_name_resolver' => 'mapped',
+                'queue_name' => 'my_default_queue_when_mapping_fails',
+                'queues_map' => array(
+                    'MyBundle\GenerateThumbnail' => 'heavy_lifting'
+                )
+            ))
+        ), array(
+            $type => array(
+                'queue_name_resolver' => 'mapped',
+                'queue_name' => 'my_default_queue_when_mapping_fails',
+                'queues_map' => array(
+                    'MyBundle\GenerateThumbnail' => 'heavy_lifting'
+                ),
+            )
+        ), $type);
+    }
+
+    /**
+     * @test
+     * @dataProvider commandsAndEventsProvider
+     */
+    public function it_should_be_possible_to_set_a_class_based_name_resolver($type)
+    {
+        $this->assertProcessedConfigurationEquals(array(
+            array($type => array(
+                'queue_name_resolver' => 'class_based',
+            ))
+        ), array(
+            $type => array(
+                'queue_name_resolver' => 'class_based',
+                'queue_name' => 'asynchronous_' . $type,
+                'queues_map' => array(),
+            )
+        ), $type);
+    }
+
+    /**
+     * @test
+     * @dataProvider commandsAndEventsProvider
+     */
+    public function it_should_be_possible_to_set_a_service_as_name_resolver($type)
+    {
+        $this->assertProcessedConfigurationEquals(array(
+            array($type => array(
+                'queue_name_resolver' => 'my.service.id',
+            ))
+        ), array(
+            $type => array(
+                'queue_name_resolver' => 'my.service.id',
+                'queue_name' => 'asynchronous_' . $type,
+                'queues_map' => array(),
+            )
+        ), $type);
+    }
+
+    public function commandsAndEventsProvider()
+    {
+        return [
+            ['commands'],
+            ['events'],
+        ];
+    }
+}

--- a/tests/Routing/ClassBasedQueueNameResolverTest.php
+++ b/tests/Routing/ClassBasedQueueNameResolverTest.php
@@ -2,9 +2,9 @@
 
 namespace SimpleBus\BernardBundleBridge\Tests\Routing;
 
-use SimpleBus\BernardBundleBridge\Routing\DefaultQueueNameResolver;
+use SimpleBus\BernardBundleBridge\Routing\ClassBasedQueueNameResolver;
 
-class DefaultQueueNameResolverTest extends \PHPUnit_Framework_TestCase
+class ClassBasedQueueNameResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider getData
@@ -14,7 +14,7 @@ class DefaultQueueNameResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolveRoutingKeyFor($message, $expected)
     {
-        $queueName = (new DefaultQueueNameResolver())->resolveRoutingKeyFor($message);
+        $queueName = (new ClassBasedQueueNameResolver())->resolveRoutingKeyFor($message);
 
         $this->assertEquals($expected, $queueName);
     }

--- a/tests/Routing/FixedQueueNameResolverTest.php
+++ b/tests/Routing/FixedQueueNameResolverTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SimpleBus\BernardBundleBridge\Tests\Routing;
+
+use SimpleBus\BernardBundleBridge\Routing\FixedQueueNameResolver;
+use stdClass;
+
+class FixedQueueNameResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResolveRoutingKeyFor()
+    {
+        $queueName = (new FixedQueueNameResolver('fixed-queue-name'))->resolveRoutingKeyFor(new stdClass);
+
+        $this->assertEquals('fixed-queue-name', $queueName);
+    }
+}

--- a/tests/Routing/MappedQueueNameResolverTest.php
+++ b/tests/Routing/MappedQueueNameResolverTest.php
@@ -13,27 +13,13 @@ class MappedQueueNameResolverTest extends \PHPUnit_Framework_TestCase
             __NAMESPACE__.'\\FooBarCommand' => 'foo_bar_queue',
             __NAMESPACE__.'\\FooBarEvent' => 'foo_bar_event_queue',
             __NAMESPACE__.'\\FooBarCommandEvent' => 'foo_bar_command_queue',
-        ]);
+        ], 'my-fallback-queue');
 
         $this->assertEquals('foo_queue', $resolver->resolveRoutingKeyFor(new FooBar()));
         $this->assertEquals('foo_bar_queue', $resolver->resolveRoutingKeyFor(new FooBarCommand()));
         $this->assertEquals('foo_bar_event_queue', $resolver->resolveRoutingKeyFor(new FooBarEvent()));
         $this->assertEquals('foo_bar_command_queue', $resolver->resolveRoutingKeyFor(new FooBarCommandEvent()));
-
-        return $resolver;
-    }
-
-    /**
-     * @param MappedQueueNameResolver $resolver
-     *
-     * @depends testResolveRoutingKeyFor
-     *
-     * @expectedException        \RuntimeException
-     * @expectedExceptionMessage Unable to detect queue for message of type SimpleBus\BernardBundleBridge\Tests\Routing\Baz.
-     */
-    public function testResolveRoutingKeyForWithUnsupportedMessage(MappedQueueNameResolver $resolver)
-    {
-        $resolver->resolveRoutingKeyFor(new Baz());
+        $this->assertEquals('my-fallback-queue', $resolver->resolveRoutingKeyFor(new \stdClass));
     }
 }
 


### PR DESCRIPTION
Current implementation only allows 1 `queue_name_resolver`. 
SimpleBusRabbitMqBundle defaults to two queues: `asynchronous_commands` and `asynchronous_events`. This pull request does the same thing. 

The default configuration:
```yaml
simple_bus_bernard_bundle_bridge: ~
```

is the same as:
```yaml
simple_bus_bernard_bundle_bridge:
    commands: asynchronous_commands
    events: asynchronous_events
```

and the same as 
```yaml
simple_bus_bernard_bundle_bridge:
    commands:
        queue_name_resolver: fixed
        queue_name: asynchronous_commands
    events:
        queue_name_resolver: fixed
        queue_name: asynchronous_events
```

The `queue_name_resolver` property can contain the following: `fixed` (default), `mapped`, `class_based` or a service id.

I also renamed `DefaultQueueNameResolver` to `ClassBasedQueueNameResolver`. 

Tests are added for the Configuration